### PR TITLE
[0.5.1] `zeus which 0x123123123......`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **[pending]** 
 0.5.1:
 - `zeus upgrade new` has been renamed `zeus upgrade register` and now supports updating existing upgrades.
+- `zeus which` now supports addresses, and will tell you what an address is on any network. Neat!
 
 **[historical]**
 0.5.0:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
- `zeus which` can now tell you what an address corresponds to across all environments.

<img width="687" alt="image" src="https://github.com/user-attachments/assets/e9b52550-7c98-4162-bffa-1e11c6883ed8">
