### PR TITLE
[1.2.2] Fix etherscan prompt missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **[Current]** 
+1.2.2:
+- A bug which resulted in etherscanApiKey not being prompted.
 
 1.2.1:
 - Minor bugfixes / improvements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/deploy/cmd/run.ts
+++ b/src/commands/deploy/cmd/run.ts
@@ -188,7 +188,7 @@ export async function handler(_user: TState, args: {env: string, resume: boolean
                     anvil,
                     testClient,
                     overrideEoaPk,
-                    etherscanApiKey: !args.fork,
+                    etherscanApiKey: args.fork ? false : undefined,
                 },
                 nonInteractive: !!args.fork
             });
@@ -237,7 +237,7 @@ export async function handler(_user: TState, args: {env: string, resume: boolean
                 anvil,
                 testClient,
                 overrideEoaPk,
-                etherscanApiKey: !args.fork,
+                etherscanApiKey: args.fork ? false : undefined,
             },
             nonInteractive: !!args.fork
         });

--- a/src/signing/strategies/eoa/eoa.ts
+++ b/src/signing/strategies/eoa/eoa.ts
@@ -23,11 +23,13 @@ export default abstract class EOABaseSigningStrategy extends Strategy {
         }, 'rpcUrl')
         this.etherscanApiKey = this.arg(async () => {
             if (options?.defaultArgs.fork) {
+                console.log(`ignoring etherscanApiKey - won't prompt again (fork).`)
                 return false;
             }
 
             const res = await prompts.etherscanApiKey();
             if (!res) {
+                console.log(`ignoring etherscanApiKey - won't prompt again (user-declined).`)
                 return false;
             }
             return res;

--- a/src/signing/strategies/eoa/eoa.ts
+++ b/src/signing/strategies/eoa/eoa.ts
@@ -23,13 +23,11 @@ export default abstract class EOABaseSigningStrategy extends Strategy {
         }, 'rpcUrl')
         this.etherscanApiKey = this.arg(async () => {
             if (options?.defaultArgs.fork) {
-                console.log(`ignoring etherscanApiKey - won't prompt again (fork).`)
                 return false;
             }
 
             const res = await prompts.etherscanApiKey();
             if (!res) {
-                console.log(`ignoring etherscanApiKey - won't prompt again (user-declined).`)
                 return false;
             }
             return res;

--- a/src/tests/deploy/mock.ts
+++ b/src/tests/deploy/mock.ts
@@ -3,6 +3,8 @@ import { MockStrategy } from './mockStrategy';
 import { TDeployPhase, TEnvironmentManifest } from '../../metadata/schema';
 import { SavebleDocument, Transaction } from '../../metadata/metadataStore';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { promptForStrategyWithOptions } from '../../commands/deploy/cmd/utils-strategies';
+import type { Strategy } from '../../signing/strategy';
 
 jest.unstable_mockModule('../../signing/strategies/ledger/account', () => ({
     // replace ledger with a hardcoded account
@@ -10,6 +12,19 @@ jest.unstable_mockModule('../../signing/strategies/ledger/account', () => ({
     DEFAULT_BASE_DERIVATION_PATH: ``,
     BASE_DERIVATION_PATH: ``
 }))
+
+
+jest.unstable_mockModule(`../../commands/deploy/cmd/utils-strategies`, () => ({
+  promptForStrategy: jest.fn<typeof import("../../commands/deploy/cmd/utils-strategies").promptForStrategy>(),
+  promptForStrategyWithOptions: jest.fn<typeof import("../../commands/deploy/cmd/utils-strategies").promptForStrategyWithOptions>()
+}))
+
+const utilsStrategies = await import(`../../commands/deploy/cmd/utils-strategies`);
+
+export function mockNextSelectedStrategy(strategy: Strategy) {
+  (utilsStrategies.promptForStrategy as jest.Mock<typeof import("../../commands/deploy/cmd/utils-strategies").promptForStrategy>).mockResolvedValueOnce(strategy);
+  (utilsStrategies.promptForStrategyWithOptions as jest.Mock<typeof import("../../commands/deploy/cmd/utils-strategies").promptForStrategyWithOptions>).mockResolvedValueOnce(strategy);
+}
 
 export function mockEnvManifest(): TEnvironmentManifest {
   return {

--- a/src/tests/deploy/mockStrategy.ts
+++ b/src/tests/deploy/mockStrategy.ts
@@ -4,7 +4,30 @@ import { Strategy, TForgeRequest, TStrategyOptions } from "../../signing/strateg
 import { jest } from '@jest/globals';
 import { TForgeOutput, TForgeRun } from "../../signing/utils";
 
-const forgeSampleRun: TForgeRun = {
+export const mockForgeScriptOutput = {
+    stateUpdates: [],
+    contractDeploys: [],
+    output: {
+        timestamp: 0,
+        chain: 0, 
+        success: true,
+        returns: {
+            '0': {
+                value: ''
+            }
+        },
+        transactions: [],
+        logs: [],
+        raw_logs: [],
+        traces: [],
+        gas_used: 0,
+        labeled_addresses: {},
+        returned: null,
+        address: null
+    }
+}
+
+export const forgeSampleRun: TForgeRun = {
     timestamp: 0,
     chain: 1,
     transactions: [{
@@ -23,7 +46,7 @@ const forgeSampleRun: TForgeRun = {
     address: '0x123'
 };
 
-const mockForgeOutput: TForgeRequest = {
+export const mockForgeOutput: TForgeRequest = {
     output: forgeSampleRun,
     stateUpdates: [], 
     forge: {
@@ -36,7 +59,7 @@ const mockForgeOutput: TForgeRequest = {
     ready: true
 };
 
-export abstract class MockStrategy extends Strategy {
+export class MockStrategy extends Strategy {
     id = "ledger";
     description = "mock";
 


### PR DESCRIPTION
1.2.2:
- A bug in the default value for `etherscanApiKey`. If `fork` wasn't set, this resulted in 'false' which stopped the prompting pattern. This area isn't currently covered by unit tests -- the downstream codepath has tests added in this PR to confirm that setting etherscanApiKey correctly results in the prompt.