### PR TITLE
[1.2.4] feat: Add $ZEUS_DEPLOY_{FROM,TO}_VERSION to running tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 **[Current]** 
+1.2.4:
+- Adds `ZEUS_DEPLOY_FROM_VERSION` and `ZEUS_DEPLOY_TO_VERSION`, automatically injected to scripts and all tasks run via `zeus run`.
+
 1.2.3:
 - Zeus automatically displays messages indicating the user should upgrade now.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
- Automatically inject the `from` and `to` properties for an upgrade, for any logging or downstream semver.
- Eigen will immediately use this to provide a semver on all of our contracts, for EIP-712 versioned domains.