### PR TITLE
[1.3.2] Support `zeus deploy verify` for multisig steps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 **[Current]** 
+1.3.2:
+- `zeus deploy verify` now allows checking the correctness of the most recent submitted gnosis transaction.
+
 1.3.1:
 - Adds `ZEUS_DEPLOY_FROM_VERSION` and `ZEUS_DEPLOY_TO_VERSION`, automatically injected to scripts, upgrades, and all tasks run via `zeus run`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/deploy/handlers/gnosis.ts
+++ b/src/deploy/handlers/gnosis.ts
@@ -155,6 +155,8 @@ export async function executeMultisigPhase(deploy: SavebleDocument<TDeploy>, met
             const safeApi = new SafeApiKit({chainId: BigInt(deploy._.chainId), txServiceUrl: overrideTxServiceUrlForChainId(deploy._.chainId)})
             const multisigTxn = await safeApi.getTransaction(safeTxHash);
 
+            console.log(JSON.stringify(multisigTxn, null, 2));
+
             if (multisigTxn.confirmations?.length === multisigTxn.confirmationsRequired) {
                 console.log(chalk.green(`SafeTxn(${safeTxHash}): ${multisigTxn.confirmations?.length}/${multisigTxn.confirmationsRequired} confirmations received!`))
                 await advance(deploy);

--- a/src/signing/strategies/gnosis/api/gnosisApi.ts
+++ b/src/signing/strategies/gnosis/api/gnosisApi.ts
@@ -37,7 +37,7 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
             }
         }
 
-        console.log(`Multisig transactions to execute: `)
+        console.log(chalk.italic(`Upgrade script produced the following transactions: `))
         console.table(JSON.stringify(multisigExecuteRequests, null, 2));
 
         const protocolKitOwner1 = await Safe.init({
@@ -57,7 +57,6 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
             ),
         })
 
-        console.log(`Forming transaction...`);
         const hash = await protocolKitOwner1.getTransactionHash(txn)
 
         return {

--- a/src/signing/strategies/gnosis/gnosis.ts
+++ b/src/signing/strategies/gnosis/gnosis.ts
@@ -31,8 +31,6 @@ export abstract class GnosisSigningStrategy extends Strategy {
             throw new Error(`Failed to read deployed script address.`);
         }
 
-        console.log(`\nFiltering for transactions originating from Multisig(${_multisig})\n\n`);
-
         return output.traces.filter(trace => {
             return trace[0] === "Execution"
         }).map(


### PR DESCRIPTION
- `zeus deploy verify` now recomputes the expected gnosis txn hash and verifies that this hash is what is stored in the metadata repo. (i.e your deploying counterparty "claims" to have submitted this hash).
    
In a future patch, we should also add constraints that 
- this is the *latest* txn submitted to the given multisig (via the gnosis api).