### PR TITLE
[1.3.4] bugfix: zeus deploy verify no longer publishes commits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 **[Current]** 
+1.3.4:
+- `zeus deploy verify` no longer submits a check to the repo upon completion. Will re-add in a future patch.
+
 1.3.3:
 - `zeus test`, `zeus run`, and `zeus env show` now support `--pending`
     - exposes the latest (uncommitted) contract addresses as part of an ongoing deploy.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/deploy/cmd/verify.ts
+++ b/src/commands/deploy/cmd/verify.ts
@@ -18,7 +18,6 @@ import { getTrace } from "../../../signing/utils";
 import chalk from "chalk";
 import { readFileSync } from "fs";
 import { getRepoRoot } from "../../configs";
-import { acquireDeployLock, releaseDeployLock } from "./utils-locks";
 
 const currentUser = () => execSync('git config --global user.email').toString('utf-8').trim();
 


### PR DESCRIPTION
- 1.3.4: To avoid a race condition on the environment lock, this disables the ability for `zeus deploy verify` to write back to the metadata repo.