### PR TITLE
[feat] support --pending 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 **[Current]** 
+1.3.3:
+- `zeus test`, `zeus run`, and `zeus env show` now support `--pending`
+    - exposes the latest (uncommitted) contract addresses as part of an ongoing deploy.
+
 1.3.2:
 - `zeus deploy verify` now allows checking the correctness of the most recent submitted gnosis transaction.
 
@@ -19,7 +23,6 @@
 **Features**
 - Allows multisig steps to not return a transaction without breaking the deploy.
 - Support non-standard ChainIDs
-
 
 1.2.3:
 - Zeus automatically displays messages indicating the user should upgrade now.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.2.3",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layr-labs/zeus",
-      "version": "1.2.3",
+      "version": "1.3.2",
       "license": "BSL",
       "dependencies": {
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -1,5 +1,6 @@
 import { flag, option, string, optional, positional } from "cmd-ts";
 
+export const pending = flag({ long: 'pending', short: 'p', description: "If there is a pending deploy, incorporate unfinalized contracts as part of the zeus state. (normally, contract addresses are not finalized until a deploy completes)."});
 export const env = option({ type: string, long: 'env', short: 'e', description: "An environment, one returned from `zeus env list`" })
 export const versionOptional = option({ type: string, long: 'version', description: "The version to specify."});
 

--- a/src/signing/strategies/test.ts
+++ b/src/signing/strategies/test.ts
@@ -18,9 +18,9 @@ type TRunContextWithDeploy = TRunContextWithEnv & {
 
 type TRunContext = undefined | TRunContextWithDeploy | TRunContextWithEnv;
 
-export const runTest = async (args: {upgradePath: string, rpcUrl?: string | undefined, txn: Transaction, context: TRunContext, verbose: boolean, json: boolean, rawOutput?: boolean}) => {
+export const runTest = async (args: {upgradePath: string, withDeploy?: string | undefined, rpcUrl?: string | undefined, txn: Transaction, context: TRunContext, verbose: boolean, json: boolean, rawOutput?: boolean}) => {
     const deployContext = (args.context as TRunContextWithDeploy | undefined);
-    const _env: Record<string, string> = deployContext?.env ? (await injectableEnvForEnvironment(args.txn, deployContext.env)) : {};
+    const _env: Record<string, string> = deployContext?.env ? (await injectableEnvForEnvironment(args.txn, deployContext.env, args.withDeploy)) : {};
     const env = {
         ..._env,
         ZEUS_TEST: 'true'


### PR DESCRIPTION
See *CHANGELOG*.

- Tested locally by starting a deploy, deploying a contract, and testing that the updated contract address displayed.