### PR TITLE
[1.4.1] `zeus script`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 
 **[Current]** 
+1.4.1:
+    NEW:
+        - `zeus script --env <env> [--eoa | --multisig] ./path/to/ZeusScript.s.sol` allows running an individual portion of a migration outside of the context
+        of an upgrade! Use this if you need to interact with a multisig, deploy contracts, etc, and aren't upgrading the zeus environment's semver.
+
 1.4.0:
     Fixed:
         - Significant Performance Improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
     NEW:
         - `zeus script --env <env> [--eoa | --multisig] ./path/to/ZeusScript.s.sol` allows running an individual portion of a migration outside of the context
         of an upgrade! Use this if you need to interact with a multisig, deploy contracts, etc, and aren't upgrading the zeus environment's semver.
-
+    Fixes:
+        - Locally cloned metadata repo is now namespaced by the repo cloned, to prevent collisions.
 1.4.0:
     Fixed:
         - Significant Performance Improvements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/script.ts
+++ b/src/commands/script.ts
@@ -1,0 +1,117 @@
+import {command, restPositionals, string, flag} from 'cmd-ts';
+import {json} from './args';
+import { withHost, requires, TState } from './inject';
+import * as allArgs from './args';
+import fs from 'fs';
+import path from 'path';
+import { loadExistingEnvs } from './env/cmd/list';
+import { TDeploy, TDeployPhase, TEnvironmentManifest } from '../metadata/schema';
+import { canonicalPaths } from '../metadata/paths';
+import { SavebleDocument } from '../metadata/metadataStore';
+import { stepDeploy } from './deploy/cmd/run';
+import chalk from 'chalk';
+
+const handler = async function(user: TState, args: {scripts: string[], multisig: boolean, eoa: boolean, json: boolean, env: string}) {
+    if (!user.loggedOutMetadataStore) {
+        throw new Error('uh oh.');
+    }
+
+    // Validate script path
+    if (args.scripts.length !== 1) {
+        console.error('Exactly one script must be specified');
+        process.exit(1);
+    }
+    
+    const scriptPath = args.scripts[0];
+    if (!fs.existsSync(scriptPath)) {
+        console.error(`Script not found: ${scriptPath}`);
+        process.exit(1);
+    }
+    
+    const txn = await user.loggedOutMetadataStore.begin();
+    const envs = await loadExistingEnvs(txn);
+    
+    if (!envs.find(e => e.name === args.env)) {
+        console.error(`No such environment: ${args.env}`);
+        process.exit(1);
+    }
+    
+    // Get current environment version
+    const envManifest = await txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(args.env));
+    
+    const strategyType = args.multisig ? 'multisig' : 'eoa';
+    const startingPhase: TDeployPhase = args.multisig ? 'multisig_start' : 'eoa_validate';
+    
+    const dummyDeploy: TDeploy = {
+        name: `script-${path.basename(scriptPath)}`,
+        metadata: [],
+        startTime: new Date().toString(),
+        startTimestamp: Date.now(),
+        upgrade: '',
+        env: args.env,
+        upgradePath: path.dirname(scriptPath),
+        phase: startingPhase,
+        segmentId: 0,
+        segments: [
+            {
+                id: 0,
+                type: strategyType,
+                filename: path.basename(scriptPath)
+            }
+        ],
+        chainId: envManifest._.chainId
+    };
+    console.log(`Running script: ${chalk.bold(path.basename(scriptPath))}`);
+    
+    const deployDoc = {
+        _: dummyDeploy,
+        save: async () => {
+            //
+        },
+        path: ''
+    } as SavebleDocument<TDeploy>;
+    
+    try {
+        while (dummyDeploy.phase !== 'complete') {
+            await stepDeploy(deployDoc, user, txn, {
+                defaultArgs: {
+                    nonInteractive: false,
+                    rpcUrl: undefined,
+                    fork: undefined
+                },
+                nonInteractive: false
+            });
+        }
+        
+        console.log(`Script execution completed successfully: ${scriptPath}`);
+    } catch (error) {
+        console.error(`Script execution failed (phase=${dummyDeploy.phase},segment=${dummyDeploy.segmentId+1}/${dummyDeploy.segments.length})`);
+        console.error(error);
+        process.exit(1);
+    }
+};
+
+const cmd = command({
+    name: 'script',
+    description: 'Run a forge script that extends `ZeusScript`',
+    version: '1.0.0',
+    args: {
+        json,
+        env: allArgs.env,
+        multisig: flag({
+            long: 'multisig',
+            description: 'Use multisig signing strategy',
+        }),
+        eoa: flag({
+            long: 'eoa',
+            description: 'Use EOA signing strategy',
+        }),
+        scripts: restPositionals({
+            type: string,
+            description: 'Path to script to execute'
+        })
+    },
+    handler: requires(handler, withHost),
+})
+
+export default cmd;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import pkgInfo from '../package.json';
 import { execSync } from 'child_process';
 import { compare } from 'compare-versions';
 import { configs } from './commands/configs';
+import script from './commands/script';
 
 const HOURS = (1000) * (60) * (60);
 
@@ -53,7 +54,7 @@ const main = async () => {
 
         ${chalk.italic(`(zeus v${zeusInfo.Version}-${process.env.ZEUS_BUILD})`)}
         `,
-        cmds: { deploy, env, upgrade, login, run: runCmd, test: testCmd, init: initCmd, which, shell },
+        cmds: { deploy, env, upgrade, login, run: runCmd, test: testCmd, init: initCmd, which, shell, script },
     });
     run(zeus, process.argv.slice(2));
 }

--- a/src/metadata/clone/LocalCloneMetadataStore.ts
+++ b/src/metadata/clone/LocalCloneMetadataStore.ts
@@ -5,6 +5,7 @@ const exec = promisify(execCallback);
 import { MetadataStore, Transaction } from '../metadataStore';
 import { LocalCloneTransaction } from './LocalCloneTransaction';
 import { existsSync, mkdirSync, rmdirSync } from 'fs';
+import { keccak256, toHex } from 'viem';
 
 
 // -------------------------------------------------------
@@ -35,9 +36,11 @@ export class LocalCloneMetadataStore implements MetadataStore {
             return;
         }
         this.initialized = true;
+
+        const loc = keccak256(toHex(this.remoteRepoUrl)).substring(2, 8); // 6 strings 
         
-        const localUrl = path.join(process.env.HOME as string, '.zeus', 'data');
-        const localUrlGit = path.join(process.env.HOME as string, '.zeus', 'data', '.git');
+        const localUrl = path.join(process.env.HOME as string, '.zeus', 'data', loc);
+        const localUrlGit = path.join(process.env.HOME as string, '.zeus', 'data', loc, '.git');
         try {
             if (!existsSync(localUrl) || !existsSync(localUrlGit)) {
                 try {

--- a/src/metadata/clone/LocalCloneTransaction.ts
+++ b/src/metadata/clone/LocalCloneTransaction.ts
@@ -86,7 +86,7 @@ export class LocalCloneTransaction implements Transaction {
 
             const basePath = path.dirname(outPath);
             if (!await exists(basePath)) {
-                await fs.mkdir(basePath);
+                await fs.mkdir(basePath, {recursive: true});
             }
 
             await fs.writeFile(outPath, toWrite);


### PR DESCRIPTION
1.4.1:
    NEW:
        - `zeus script --env <env> [--eoa | --multisig] ./path/to/ZeusScript.s.sol` allows running an individual portion of a migration outside of the context
        of an upgrade! Use this if you need to interact with a multisig, deploy contracts, etc, and aren't upgrading the zeus environment's semver.
    Fixes:
        - Locally cloned metadata repo is now namespaced by the repo cloned, to prevent collisions.