### PR TITLE
[1.4.2] Auto set `ZEUS_DEPLOYED_TO` and `ZEUS_DEPLOYED_FROM`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 **[Current]** 
 1.4.2:
     Change:
-        - `ZEUS_DEPLOYED_TO` and `ZEUS_DEPLOYED_FROM` are automatically set during test executions.
+        - `ZEUS_DEPLOYED_TO` and `ZEUS_DEPLOYED_FROM` are automatically set during test executions, based on the nearest `upgrade.json`.
 
 1.4.1:
     NEW:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 **[Current]** 
+1.4.2:
+    Change:
+        - `ZEUS_DEPLOYED_TO` and `ZEUS_DEPLOYED_FROM` are automatically set during test executions.
+
 1.4.1:
     NEW:
         - `zeus script --env <env> [--eoa | --multisig] ./path/to/ZeusScript.s.sol` allows running an individual portion of a migration outside of the context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -54,9 +54,9 @@ export interface TBaseZeusEnv {
     ZEUS_ENV_VERSION: string
     ZEUS_VERSION: string
 
-    // information from the zeus upgrade object (from => to)
-    ZEUS_DEPLOY_FROM_VERSION: string,
-    ZEUS_DEPLOY_TO_VERSION: string,
+    // information from the zeus upgrade object (from => to).
+    ZEUS_DEPLOY_FROM_VERSION?: string,
+    ZEUS_DEPLOY_TO_VERSION?: string,
 }
 
 // if `withDeploy` is specified, we also inject instances/statics updated as part of the deploy.
@@ -105,8 +105,11 @@ export const injectableEnvForEnvironment: (txn: Transaction, env: string, withDe
         ZEUS_TEST: 'false', /* test environments should override this */
         ZEUS_ENV_VERSION: envManifest._.deployedVersion,
 
-        ZEUS_DEPLOY_FROM_VERSION: upgradeInfo?._.from ?? ``,
-        ZEUS_DEPLOY_TO_VERSION: upgradeInfo?._.to ?? ``,
+        // only apply `ZEUS_DEPLOY_FROM_VERSION` and `ZEUS_DEPLOY_TO_VERSION` if a deploy is set.
+        ...(upgradeInfo?._.from || upgradeInfo?._.to ? {
+            ZEUS_DEPLOY_FROM_VERSION: upgradeInfo?._.from,
+            ZEUS_DEPLOY_TO_VERSION: upgradeInfo?._.to,
+        } : {}),
 
         ZEUS_VERSION: zeusInfo.Version,
         ...(deployParametersToEnvironmentVariables({

--- a/src/deploy/handlers/eoa.ts
+++ b/src/deploy/handlers/eoa.ts
@@ -50,7 +50,7 @@ export async function executeEOAPhase(deploy: SavebleDocument<TDeploy>, metatxn:
             const prompt = ora(`Running 'zeus test'`);
             const spinner = prompt.start();
             try {
-                const res = await runTest({upgradePath: script, rpcUrl, txn: metatxn, context: {env: deploy._.env, deploy: deploy._.name}, verbose: false, json: true})
+                const res = await runTest({env: deploy._.env, upgradePath: script, rpcUrl, txn: metatxn, context: {deploy: deploy._.name}, verbose: false, json: true})
                 if (res.code !== 0) {
                     throw new HaltDeployError(deploy, `One or more tests failed.`, false);
                 }

--- a/src/deploy/handlers/gnosis.ts
+++ b/src/deploy/handlers/gnosis.ts
@@ -42,7 +42,7 @@ export async function executeMultisigPhase(deploy: SavebleDocument<TDeploy>, met
                 const prompt = ora(`Running 'zeus test'`);
                 const spinner = prompt.start();
                 try {
-                    const res = await runTest({upgradePath: script, rpcUrl, txn: metatxn, context: {env: deploy._.env, deploy: deploy._.name}, verbose: false, json: true})
+                    const res = await runTest({env: deploy._.env, upgradePath: script, rpcUrl, txn: metatxn, context: {deploy: deploy._.name}, verbose: false, json: true})
                     if (res.code !== 0) {
                         throw new HaltDeployError(deploy, `One or more tests failed.`, false);
                     }

--- a/src/signing/strategies/test.ts
+++ b/src/signing/strategies/test.ts
@@ -7,28 +7,71 @@ import { canonicalPaths } from "../../metadata/paths";
 import { TEnvironmentManifest } from "../../metadata/schema";
 import { Chain } from 'viem';
 import { getChainId } from "../../commands/prompts";
+import { dirname, join, resolve } from "path";
+import { readdirSync, readFileSync } from "fs";
+import { getRepoRoot } from "../../commands/configs";
+import { TUpgrade } from "../../metadata/schema";
 
-interface TRunContextWithEnv {
-    env: string // in the context of an env.
-};
 
-type TRunContextWithDeploy = TRunContextWithEnv & {
-    deploy: string; // in the context of an ongoing deploy.
+interface TRunContextWithDeploy {
+    deploy: string | undefined; // in the context of an ongoing deploy.
+}
+type TRunContext = undefined | TRunContextWithDeploy;
+
+const closestUpgradeJson: (upgradePath: string) => TUpgrade = (upgradePath: string) => {
+    const fullScriptPath = join(process.cwd(), upgradePath);
+
+    let searchPath = join(process.cwd(), dirname(upgradePath));
+    const repoRoot = getRepoRoot();
+
+    while (searchPath.includes(repoRoot)) {
+        const files = readdirSync(searchPath);
+        if (files.includes('upgrade.json')) {
+            const upgradeJsonPath = join(searchPath, 'upgrade.json');
+            try {
+                const contents = JSON.parse(readFileSync(upgradeJsonPath, {encoding: 'utf-8'})) as TUpgrade;
+                // confirm that `phases` contains this file.
+                
+                const matchingScript = contents.phases.filter(
+                    phase => join(dirname(upgradeJsonPath), phase.filename) === fullScriptPath
+                )
+                if (matchingScript.length === 0) {
+                    throw new Error(`The closest upgrade.json didn't include ${upgradePath}. Please check the 'phases' property of your upgrade.`);
+                }
+
+                return contents;
+            } catch (e) {
+                console.error(chalk.yellow(`failed to parse upgrade.json (${upgradeJsonPath})`));
+                throw e;
+            }
+        }
+
+        // check the current directory for upgrade.json
+        // see if the upgrade.json lists this file.
+        searchPath = resolve(join(searchPath, '..'));
+    }
+
+    throw new Error(`failed to locate upgrade.json relative to ${upgradePath}`);
 }
 
-type TRunContext = undefined | TRunContextWithDeploy | TRunContextWithEnv;
+export const runTest = async (args: {env: string, upgradePath: string, withDeploy?: string | undefined, rpcUrl?: string | undefined, txn: Transaction, context: TRunContext, verbose: boolean, json: boolean, rawOutput?: boolean}) => {
+    const _env: Record<string, string> = await injectableEnvForEnvironment(args.txn, args.env, args.withDeploy);
+    const envConfig = await args.txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(args.env));
 
-export const runTest = async (args: {upgradePath: string, withDeploy?: string | undefined, rpcUrl?: string | undefined, txn: Transaction, context: TRunContext, verbose: boolean, json: boolean, rawOutput?: boolean}) => {
-    const deployContext = (args.context as TRunContextWithDeploy | undefined);
-    const _env: Record<string, string> = deployContext?.env ? (await injectableEnvForEnvironment(args.txn, deployContext.env, args.withDeploy)) : {};
+    const upgradeJson = closestUpgradeJson(args.upgradePath);
+    const impliedFrom = envConfig._.deployedVersion;
+    const impliedTo = upgradeJson.to; // TODO: load the `upgrade.json` that is closest to `upgradePath`. Fail if you reach the repo root without finding one.
+    
     const env = {
-        ..._env,
+        ZEUS_DEPLOY_FROM_VERSION: impliedFrom,
+        ZEUS_DEPLOY_TO_VERSION: impliedTo,
+        ..._env, // NOTE: this is placed here on purpose, s.t if `_env` injects a more accurate `DEPLOY_TO_VERSION` it takes precedence.
         ZEUS_TEST: 'true'
     };
 
-    if (args.rpcUrl && deployContext?.env) {
-        // check that the rpc url 
-        const envObj = await args.txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(deployContext.env));
+    if (args.rpcUrl) {
+        // check that the rpc url chainId matches
+        const envObj = await args.txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(args.env));
         const chainId = await getChainId(args.rpcUrl);
         if (chainId !== envObj._.chainId) {
             throw new Error(`The provided RPC did not correspond to ChainID ${chainId}`);
@@ -36,13 +79,11 @@ export const runTest = async (args: {upgradePath: string, withDeploy?: string | 
     }
 
     const additionalArgs = [];
-    if (deployContext?.env) {
-        const envObj = await args.txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(deployContext.env));
-        const chain = Object.values((allChains as unknown as Chain<undefined>[])).find(chain => chain.id === envObj._.chainId)
-        const rpcUrl = args.rpcUrl ?? (chain?.rpcUrls ? Object.values(chain.rpcUrls)[0].http[0] : undefined);
-        if (rpcUrl) {
-            additionalArgs.push(...['--rpc-url', rpcUrl])
-        }
+    const envObj = await args.txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(args.env));
+    const chain = Object.values((allChains as unknown as Chain<undefined>[])).find(chain => chain.id === envObj._.chainId)
+    const rpcUrl = args.rpcUrl ?? (chain?.rpcUrls ? Object.values(chain.rpcUrls)[0].http[0] : undefined);
+    if (rpcUrl) {
+        additionalArgs.push(...['--rpc-url', rpcUrl])
     }
 
     if (args.verbose) {

--- a/src/signing/strategies/test.ts
+++ b/src/signing/strategies/test.ts
@@ -59,9 +59,10 @@ export const runTest = async (args: {env: string, upgradePath: string, withDeplo
     const envConfig = await args.txn.getJSONFile<TEnvironmentManifest>(canonicalPaths.environmentManifest(args.env));
 
     const upgradeJson = closestUpgradeJson(args.upgradePath);
-    const impliedFrom = envConfig._.deployedVersion;
-    const impliedTo = upgradeJson.to; // TODO: load the `upgrade.json` that is closest to `upgradePath`. Fail if you reach the repo root without finding one.
     
+    const impliedFrom = envConfig._.deployedVersion;
+    const impliedTo = upgradeJson.to; 
+
     const env = {
         ZEUS_DEPLOY_FROM_VERSION: impliedFrom,
         ZEUS_DEPLOY_TO_VERSION: impliedTo,


### PR DESCRIPTION
```
1.4.2:
    Change:
        - `ZEUS_DEPLOYED_TO` and `ZEUS_DEPLOYED_FROM` are automatically set during test executions, based on the nearest `upgrade.json`.
```