### PR TITLE
[1.4.3] `zeus deploy verify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 **[Current]** 
+1.4.3:
+    Fixes:
+        - `zeus deploy verify` no longer requires access to a signer private key.
+
 1.4.2:
     Change:
         - `ZEUS_DEPLOYED_TO` and `ZEUS_DEPLOYED_FROM` are automatically set during test executions, based on the nearest `upgrade.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 **[Current]** 
 1.4.3:
     Fixes:
-        - `zeus deploy verify` no longer requires access to a signer private key.
+        - `zeus deploy verify` 
+            - no longer requires access to a signer private key.
+            - now accepts --deploy for post-facto verifying a completed deploy.
+        
 
 1.4.2:
     Change:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -21,6 +21,7 @@ export const rpcUrl = option({ type: optional(string), long: 'rpcUrl', short: 'r
 export const requiredRpcUrl = option({ type: string, long: 'rpcUrl', short: 'r', description: "Provide an RPC url."});
 
 export const signer = option({type: string, long: 'signer', short: 's', description: "An ethereum private key"});
+export const deploy = option({type: optional(string), long: 'deploy', short: 'd', description: "The name of a deploy to check. If not supplied, uses the current active deploy."})
 
 export const nonInteractive = flag({
     long: 'nonInteractive',

--- a/src/commands/deploy/cmd/verify.ts
+++ b/src/commands/deploy/cmd/verify.ts
@@ -5,12 +5,12 @@ import { assertInRepo, withHost, requires, TState } from "../../inject";
 import { loadExistingEnvs } from "../../env/cmd/list";
 import { execSync } from "child_process";
 import ora from "ora";
-import { pickStrategy, rpcUrl } from "../../prompts";
+import { rpcUrl } from "../../prompts";
 import { getActiveDeploy } from "./utils";
 import * as AllChains from "viem/chains";
 import { canonicalPaths } from "../../../metadata/paths";
 import { TForgeRequest, TGnosisRequest } from "../../../signing/strategy";
-import { ForgeSolidityMetadata, TDeployedContractsManifest } from "../../../metadata/schema";
+import { ForgeSolidityMetadata, TDeploy, TDeployedContractsManifest } from "../../../metadata/schema";
 import { createPublicClient, hexToBytes, http, toHex } from "viem";
 import { join } from "path";
 import { computeFairHash } from "../utils";
@@ -18,6 +18,8 @@ import { getTrace } from "../../../signing/utils";
 import chalk from "chalk";
 import { readFileSync } from "fs";
 import { getRepoRoot } from "../../configs";
+import EOASigningStrategy from "../../../signing/strategies/eoa/privateKey";
+import { GnosisEOAApiStrategy } from "../../../signing/strategies/gnosis/api/gnosisEoa";
 
 const currentUser = () => execSync('git config --global user.email').toString('utf-8').trim();
 
@@ -44,7 +46,7 @@ const shortenHex = (str: string) => {
     return str.substring(0, 5) + '...' + str.substring(str.length - 4);
 }
 
-async function handler(_user: TState, args: {env: string}) {
+async function handler(_user: TState, args: {env: string, deploy: string | undefined}) {
     try {
         const user = assertInRepo(_user);
         const metatxn = await user.loggedOutMetadataStore.begin();
@@ -55,9 +57,12 @@ async function handler(_user: TState, args: {env: string}) {
             return;
         }
 
-        const deploy = await getActiveDeploy(metatxn, args.env);
+        const deploy = args.deploy === undefined ? await getActiveDeploy(metatxn, args.env) : await metatxn.getJSONFile<TDeploy>(
+            canonicalPaths.deployStatus({env: args.env, name: args.deploy})
+        );
+
         if (!deploy) {
-            console.error(`No active deploy to verify.`);
+            console.error(`No deploy to verify.`);
             return;
         }
         
@@ -73,225 +78,207 @@ async function handler(_user: TState, args: {env: string}) {
             prompt.stopAndPersist();
         }
         const deployedContracts = await metatxn.getJSONFile<TDeployedContractsManifest>(canonicalPaths.deployDeployedContracts(deploy._));
-
         if (!deployedContracts._?.contracts?.length || deployedContracts._?.contracts?.length === 0) {
             console.warn(`The remote claimed to produce no contracts as part of this upgrade so far. Re-run verify after some contracts are deployed.`);
             return;
         }
-
-        const strategyId = await pickStrategy([
-            {id: 'eoa', description: 'Private Key'},
-            {id: 'ledger', description: 'Ledger'}
-        ], "How would you like to supply the signer used for simulation?");
-
-        const strategy = await (async () => {
-            const all = await import('../../../signing/strategies/strategies');
-            const strategy = all.all.find(s => new s(deploy, metatxn, {nonInteractive: false, defaultArgs: {}}).id === strategyId);
-            if (!strategy) {
-                throw new Error(`Unknown strategy`);
-            }
-            return new strategy(deploy, metatxn, {nonInteractive: false, defaultArgs: {rpcUrl: customRpcUrl, etherscanApiKey: false}});
-        })();
-
-        const eoaPhases = deploy._.segments.filter(segment => segment.id <= deploy._.segmentId)
-        if (!eoaPhases) {
-            console.error(`Failed to find any contract deployments.`);
-            return;
-        }
-
-        const script = join(deploy._.upgradePath, deploy._.segments[eoaPhases[0].id].filename);
-        const prep = await strategy.prepare(script, deploy._) as TForgeRequest;
-        if (!prep.deployedContracts || !prep.forge) {
-            if (deployedContracts._?.contracts?.length > 0) {
-                console.error(`The local copy didn't produce any contracts, but the remote claimed to produce the following contracts.`);
-                console.table(deployedContracts._.contracts)
-                console.error(`Make sure you're on the correct commit, and double check any deployed contracts before proceeding...`);
-                return;
-            }
-
-            console.log(`Both the local and remote copy didn't produce any contracts.`);
-            console.log(`This is not a bug -- the uprgade just didn't deploy anything.`)
-            return;
-        }
-
-        if (deployedContracts._?.contracts?.length && deployedContracts._?.contracts?.length > 0) {
-            const chain = getChain(deploy._.chainId);
-            const publicClient = createPublicClient({chain, transport: http(customRpcUrl)})
-            const onchainBytecode: Record<string, `0x${string}`> = {};
-
-            const contractMetadata = Object.fromEntries(deployedContracts._.contracts.map(contract => {
-                const metadata = JSON.parse(readFileSync(canonicalPaths.contractJson(getRepoRoot(), cleanContractName(contract.contract)), 'utf-8')) as ForgeSolidityMetadata;
-                return [contract.contract, metadata];
-            }));
-
-            const onchainHashes = Object.fromEntries(await Promise.all(deployedContracts._.contracts.map(async contract => {
-                try {
-                    const bytecode = await publicClient.getCode({
-                        address: contract.address,
-                    })
-                    if (!bytecode) {
-                        console.warn(`Failed to compute onchain hash of ${contract.contract}@${contract.address}: failed to get code.`)
-                        return [contract.contract, undefined];
+        
+        for (let i = 0; i <= deploy._.segmentId; i++) {
+            console.log(`Verifying deploy: step (${i+1}/${deploy._.segmentId+1})...`)
+            const segment = deploy._.segments[i];
+            const script = join(deploy._.upgradePath, deploy._.segments[i].filename);
+                    
+            switch (segment.type) {
+                case 'eoa': {
+                    // get all signers.
+                    const signers = deployedContracts._.contracts.filter((contract) => contract.lastUpdatedIn.segment === i).map(contract => contract.lastUpdatedIn.signer);
+                    if (!signers || signers.length == 0) {
+                        console.log(`${i+1}: no contracts deployed.`);
+                        continue;
                     }
 
-                    onchainBytecode[contract.contract] = bytecode;
-                    const hash = computeFairHash(bytecode, contractMetadata[contract.contract]);
-                    return [contract.contract, hash]
-                } catch (e) {
-                    console.warn(`Failed to compute onchain hash of ${contract.contract}@${contract.address}`)
-                    console.warn(e);
-                    return [contract.contract, undefined];
-                }
-            })))
+                    const signer = signers[0];
+                    const strategy = new EOASigningStrategy(deploy, metatxn, {nonInteractive: false, simulationAddress: signer, defaultArgs: {rpcUrl: customRpcUrl, etherscanApiKey: false}});
+                    const prep = await strategy.prepare(script, deploy._) as TForgeRequest;
+                    
+                    if (!prep.deployedContracts || !prep.forge) {
+                        if (deployedContracts._?.contracts?.length > 0) {
+                            console.error(`The local copy didn't produce any contracts, but the remote claimed to produce the following contracts.`);
+                            console.table(deployedContracts._.contracts)
+                            console.error(`Make sure you're on the correct commit, and double check any deployed contracts before proceeding...`);
+                            return;
+                        }
 
-            const localBytecode: Record<string, `0x${string}`> = {};
-            const localBytecodeHashes = Object.fromEntries(prep.deployedContracts.map(contract => {
-                try {
-                    const trace = getTrace(prep.output, contract.address);
-                    if (!trace || !trace.trace.output) {
-                        console.warn(`Failed to find trace for contract creation simulation.`);
-                        return undefined;
+                        console.log(`Both the local and remote copy didn't produce any contracts.`);
+                        console.log(`This is not a bug -- the uprgade just didn't deploy anything.`);
                     }
-                    localBytecode[contract.contract] = trace.trace.output as `0x${string}`;
-                    const bytecodeHash = computeFairHash(trace.trace.output as `0x${string}`, contractMetadata[contract.contract]);
-                    return [contract.contract, bytecodeHash] as [string, `0x${string}`]
-                } catch (e) {
-                    console.warn(`Failed to compute bytecode hash of ${contract}`)
-                    console.error(e);
-                    return undefined;
-                }
-            }).filter(v => !!v));
 
-            const contracts = deployedContracts._.contracts;
-            const instanceCounter: Record<string, number> = {};
-            const info = Object.fromEntries(contracts.map((ctr) => {
-                const instancedContractName = `${ctr.contract}${instanceCounter[ctr.contract] ? `_${instanceCounter[ctr.contract]}` : ``}`
-                instanceCounter[ctr.contract] = (instanceCounter[ctr.contract] ?? 0) + 1;
-                return [instancedContractName, {
-                    ...ctr,
-                    yours: localBytecodeHashes[ctr.contract] ?? '<none>',
-                    onchain: onchainHashes[ctr.contract] ?? '<none>',
-                    match: !!((localBytecodeHashes[ctr.contract] === onchainHashes[ctr.contract]) && localBytecodeHashes[ctr.contract]),
-                }]
-            }))
-
-            const failures = Object.keys(info).filter(ctr => !info[ctr].match)
-            const isFailure = Object.keys(failures).length > 0;
-            if (isFailure) {
-                console.error(`FATAL: Bytecode Hashes did not match for the following contracts;`)
-                console.table(failures.map(key => {
-                    return {
-                        contract: info[key].contract,
-                        address: info[key].address,
-                        yours: shortenHex(info[key].yours),
-                        onchain: shortenHex(info[key].onchain),
-                }}));
-
-                console.log('Local bytecode keys', Object.keys(localBytecode));
-                console.log('Onchain bytecode keys', Object.keys(onchainBytecode));
-                failures.forEach(key => {
-                    const ctr = info[key].contract;
-                    console.log(chalk.bold.underline(`[${ctr}@${info[key].address}] Remote Bytecode (mismatches highlighted red):`))
-
-                    const localBytes = hexToBytes(localBytecode[ctr]);
-                    const remoteBytes = hexToBytes(onchainBytecode[ctr]);
-
-                    remoteBytes.forEach((remoteByte, i) => {
-                        if (localBytes[i] !== remoteByte) {
-                            process.stdout.write(chalk.bgWhite.red(toHex(remoteByte).substring(2)));
+                    if (deployedContracts._?.contracts?.length && deployedContracts._?.contracts?.length > 0) {
+                        const chain = getChain(deploy._.chainId);
+                        const publicClient = createPublicClient({chain, transport: http(customRpcUrl)})
+                        const onchainBytecode: Record<string, `0x${string}`> = {};
+            
+                        const contractMetadata = Object.fromEntries(deployedContracts._.contracts.map(contract => {
+                            const metadata = JSON.parse(readFileSync(canonicalPaths.contractJson(getRepoRoot(), cleanContractName(contract.contract)), 'utf-8')) as ForgeSolidityMetadata;
+                            return [contract.contract, metadata];
+                        }));
+            
+                        const onchainHashes = Object.fromEntries(await Promise.all(deployedContracts._.contracts.map(async contract => {
+                            try {
+                                const bytecode = await publicClient.getCode({
+                                    address: contract.address,
+                                })
+                                if (!bytecode) {
+                                    console.warn(`Failed to compute onchain hash of ${contract.contract}@${contract.address}: failed to get code.`)
+                                    return [contract.contract, undefined];
+                                }
+            
+                                onchainBytecode[contract.contract] = bytecode;
+                                const hash = computeFairHash(bytecode, contractMetadata[contract.contract]);
+                                return [contract.contract, hash]
+                            } catch (e) {
+                                console.warn(`Failed to compute onchain hash of ${contract.contract}@${contract.address}`)
+                                console.warn(e);
+                                return [contract.contract, undefined];
+                            }
+                        })))
+            
+                        const localBytecode: Record<string, `0x${string}`> = {};
+                        const localBytecodeHashes = Object.fromEntries(prep.deployedContracts?.map(contract => {
+                            try {
+                                const trace = getTrace(prep.output, contract.address);
+                                if (!trace || !trace.trace.output) {
+                                    console.warn(`Failed to find trace for contract creation simulation.`);
+                                    return undefined;
+                                }
+                                localBytecode[contract.contract] = trace.trace.output as `0x${string}`;
+                                const bytecodeHash = computeFairHash(trace.trace.output as `0x${string}`, contractMetadata[contract.contract]);
+                                return [contract.contract, bytecodeHash] as [string, `0x${string}`]
+                            } catch (e) {
+                                console.warn(`Failed to compute bytecode hash of ${contract}`)
+                                console.error(e);
+                                return undefined;
+                            }
+                        }).filter(v => !!v) ?? []);
+            
+                        const contracts = deployedContracts._.contracts;
+                        const instanceCounter: Record<string, number> = {};
+                        const info = Object.fromEntries(contracts.map((ctr) => {
+                            const instancedContractName = `${ctr.contract}${instanceCounter[ctr.contract] ? `_${instanceCounter[ctr.contract]}` : ``}`
+                            instanceCounter[ctr.contract] = (instanceCounter[ctr.contract] ?? 0) + 1;
+                            return [instancedContractName, {
+                                ...ctr,
+                                yours: localBytecodeHashes[ctr.contract] ?? '<none>',
+                                onchain: onchainHashes[ctr.contract] ?? '<none>',
+                                match: !!((localBytecodeHashes[ctr.contract] === onchainHashes[ctr.contract]) && localBytecodeHashes[ctr.contract]),
+                            }]
+                        }))
+            
+                        const failures = Object.keys(info).filter(ctr => !info[ctr].match)
+                        const isFailure = Object.keys(failures).length > 0;
+                        if (isFailure) {
+                            console.error(`FATAL: Bytecode Hashes did not match for the following contracts;`)
+                            console.table(failures.map(key => {
+                                return {
+                                    contract: info[key].contract,
+                                    address: info[key].address,
+                                    yours: shortenHex(info[key].yours),
+                                    onchain: shortenHex(info[key].onchain),
+                            }}));
+            
+                            console.log('Local bytecode keys', Object.keys(localBytecode));
+                            console.log('Onchain bytecode keys', Object.keys(onchainBytecode));
+                            failures.forEach(key => {
+                                const ctr = info[key].contract;
+                                console.log(chalk.bold.underline(`[${ctr}@${info[key].address}] Remote Bytecode (mismatches highlighted red):`))
+            
+                                const localBytes = hexToBytes(localBytecode[ctr]);
+                                const remoteBytes = hexToBytes(onchainBytecode[ctr]);
+            
+                                remoteBytes.forEach((remoteByte, i) => {
+                                    if (localBytes[i] !== remoteByte) {
+                                        process.stdout.write(chalk.bgWhite.red(toHex(remoteByte).substring(2)));
+                                    } else {
+                                        process.stdout.write(chalk.gray(toHex(remoteByte).substring(2)));
+                                    }
+                                });
+                                console.log();
+                            });
+            
+                            console.error(`You may: (1) be on the wrong commit, (2) have a dirty local copy, or (3) have witnessed a mistake your teammate made on the other end.`)
+                            console.error(`Please flag this, and consider cancelling your other deploy.`)
+                        }
+            
+                        console.log(chalk.bold(`Validated contracts:`));
+                        console.log(chalk.italic(`------------------------------------------------------------`));
+                        console.log(chalk.italic(`\t${chalk.green('✔')} - the hash of the local compiled contract matched the onchain version`));
+                        console.log(chalk.italic(`\t${chalk.red('x')} - the hash of the local compiled contract did not match the onchain version`));
+                        console.log(chalk.italic(`NOTE: Zeus zeros-out any immutableReferences in the contract, to avoid runtime parameters which cannot be simulated.`))
+                        console.log(chalk.italic(`------------------------------------------------------------`));
+                        console.log();
+            
+                        Object.keys(info).forEach(ctr => {
+                            const contractInfo = info[ctr];
+                            const metaContract = deployedContracts._.contracts.find(_contract => _contract.address === contractInfo.address);
+                            if (!metaContract) {
+                                console.log(`No metadata on contract ${ctr} available.`);
+                                return;
+                            }
+                            metaContract.validations = [
+                                ...(metaContract.validations ?? []),
+                                {
+                                    by: currentUser(),
+                                    valid: contractInfo.match,
+                                    expectedBytecodeHash: !contractInfo.match ? contractInfo.yours : undefined
+                                }
+                            ]
+            
+                            if (contractInfo.match) {
+                                console.log(`${chalk.green('✔')} ${ctr} (${contractInfo.address})`);
+                            } else {
+                                console.log(`${chalk.red('x')} ${ctr} (${contractInfo.address})`);
+                            }
+                        })
+            
+                        if (Object.keys(isFailure).length === 0) {
+                            console.log(chalk.green('OK'));
                         } else {
-                            process.stdout.write(chalk.gray(toHex(remoteByte).substring(2)));
+                            console.log(chalk.red(`FAILURE`));
+                            throw new Error(`Deployed contracts did not match local copy.`)
                         }
-                    });
-                    console.log();
-                });
-
-                console.error(`You may: (1) be on the wrong commit, (2) have a dirty local copy, or (3) have witnessed a mistake your teammate made on the other end.`)
-                console.error(`Please flag this, and consider cancelling your other deploy.`)
-            }
-
-            console.log(chalk.bold(`Validated contracts:`));
-            console.log(chalk.italic(`------------------------------------------------------------`));
-            console.log(chalk.italic(`\t${chalk.green('✔')} - the hash of the local compiled contract matched the onchain version`));
-            console.log(chalk.italic(`\t${chalk.red('x')} - the hash of the local compiled contract did not match the onchain version`));
-            console.log(chalk.italic(`NOTE: Zeus zeros-out any immutableReferences in the contract, to avoid runtime parameters which cannot be simulated.`))
-            console.log(chalk.italic(`------------------------------------------------------------`));
-            console.log();
-
-            Object.keys(info).forEach(ctr => {
-                const contractInfo = info[ctr];
-                const metaContract = deployedContracts._.contracts.find(_contract => _contract.address === contractInfo.address);
-                if (!metaContract) {
-                    console.log(`No metadata on contract ${ctr} available.`);
-                    return;
-                }
-                metaContract.validations = [
-                    ...(metaContract.validations ?? []),
-                    {
-                        by: currentUser(),
-                        valid: contractInfo.match,
-                        expectedBytecodeHash: !contractInfo.match ? contractInfo.yours : undefined
                     }
-                ]
-
-                if (contractInfo.match) {
-                    console.log(`${chalk.green('✔')} ${ctr} (${contractInfo.address})`);
-                } else {
-                    console.log(`${chalk.red('x')} ${ctr} (${contractInfo.address})`);
+                    break;
                 }
-            })
+                case 'multisig': {
+                    const multisigRun = await metatxn.getJSONFile<TGnosisRequest>(canonicalPaths.multisigRun({deployEnv: deploy._.env, deployName: deploy._.name, segmentId: deploy._.segmentId}))
+                    const proposedTxHash = multisigRun._.safeTxHash;
+                    const signer = multisigRun._.senderAddress;
+                    const strategy = new GnosisEOAApiStrategy(deploy, metatxn, {nonInteractive: false, simulationAddress: signer, defaultArgs: {rpcUrl: customRpcUrl, etherscanApiKey: false}});
+                    
+                    if (proposedTxHash) {
+                        // allow verifying the multisig txn hash.
+                        console.log(chalk.bold(`This deploy has a multisig step ongoing. Checking that the provided gnosisHash matches the local copy.`))
 
-            if (Object.keys(isFailure).length === 0) {
-                console.log(chalk.green('OK'));
-            } else {
-                console.log(chalk.red(`FAILURE`));
-                throw new Error(`Deployed contracts did not match local copy.`)
-            }
-        }
+                        const script = join(deploy._.upgradePath, deploy._.segments[deploy._.segmentId].filename);
+                        const request = await strategy.prepare(script);
+                        const gnosisTxnHash = (request as TGnosisRequest).safeTxHash;
 
-        if (deploy._.segments[deploy._.segmentId].type === 'multisig') {
-            const multisigRun = await metatxn.getJSONFile<TGnosisRequest>(canonicalPaths.multisigRun({deployEnv: deploy._.env, deployName: deploy._.name, segmentId: deploy._.segmentId}))
-            const proposedTxHash = multisigRun._.safeTxHash;
-            if (proposedTxHash) {
-                // allow verifying the multisig txn hash.
-                console.log(chalk.bold(`This deploy has a multisig step ongoing. Checking that the provided gnosisHash matches the local copy.`))
-
-                const strategyId = await pickStrategy([
-                    {id: 'gnosis.api.eoa', description: 'Gnosis / Private Key'},
-                    {id: 'gnosis.api.ledger', description: 'Gnosis / Ledger'},
-                    {id: 'cancel', description: 'Cancel'}
-                ], "How would you like to resimulate the multisig step?");
-
-                if (strategyId !== 'cancel') {
-                    const strategy = await (async () => {
-                        const all = await import('../../../signing/strategies/strategies');
-                        const strategy = all.all.find(s => new s(deploy, metatxn, {nonInteractive: false, defaultArgs: {}}).id === strategyId);
-                        if (!strategy) {
-                            throw new Error(`Unknown strategy`);
+                        if (proposedTxHash === gnosisTxnHash) {
+                            console.log(`${chalk.green('✔')} ${script} (${gnosisTxnHash})`);
+                        } else {
+                            console.error(`${chalk.red('x')} ${script} (local=${gnosisTxnHash},reported=${proposedTxHash})`);
+                            throw new Error(`Multisig transaction did not match (local=${gnosisTxnHash},reported=${proposedTxHash})`);
                         }
-                        return new strategy(deploy, metatxn, {nonInteractive: false, defaultArgs: {rpcUrl: customRpcUrl, etherscanApiKey: false}});
-                    })();
-                    const script = join(deploy._.upgradePath, deploy._.segments[deploy._.segmentId].filename);
-                    const request = await strategy.prepare(script, deploy._);
-                    const gnosisTxnHash = (request as TGnosisRequest).safeTxHash;
-
-                    if (proposedTxHash === gnosisTxnHash) {
-                        console.log(`${chalk.green('✔')} ${script} (${gnosisTxnHash})`);
                     } else {
-                        console.error(`${chalk.red('x')} ${script} (local=${gnosisTxnHash},reported=${proposedTxHash})`);
-                        throw new Error(`Multisig transaction did not match (local=${gnosisTxnHash},reported=${proposedTxHash})`);
+                        console.info(chalk.italic(`[${i+1}] step has not yet proposed a transaction. Nothing to validate.`))
                     }
-                } else {
-                    console.log(chalk.italic(`skipping gnosis verification`))
+
+                    break;
                 }
-            } else {
-                console.info(chalk.italic(`Multisig step found: [${deploy._.segmentId}] has not yet proposed a transaction. Nothing to validate.`))
             }
         }
-
     } catch (e) {
         console.error(`Failed to verify deploy.`);
-        console.error(e);
         throw e;
     }
 }
@@ -303,6 +290,7 @@ const cmd = command({
     args: {
         env: allArgs.env,
         json,
+        deploy: allArgs.deploy
     },
     handler: requires(handler, withHost),
 })

--- a/src/deploy/handlers/eoa.ts
+++ b/src/deploy/handlers/eoa.ts
@@ -136,7 +136,8 @@ export async function executeEOAPhase(deploy: SavebleDocument<TDeploy>, metatxn:
                             lastUpdatedIn: {
                                 name: deploy._.name,
                                 phase: deploy._.phase,
-                                segment: deploy._.segmentId
+                                segment: deploy._.segmentId,
+                                signer: sigRequest.signer,
                             },
                         };
                     }) || []);

--- a/src/metadata/schema.ts
+++ b/src/metadata/schema.ts
@@ -363,7 +363,8 @@ export interface TDeployedContract extends TDeployedContractSparse {
     lastUpdatedIn: {
         name: string,
         phase: string;
-        segment: number
+        segment: number;
+        signer: string;
     };
 }
 

--- a/src/signing/strategies/eoa/privateKey.ts
+++ b/src/signing/strategies/eoa/privateKey.ts
@@ -14,7 +14,6 @@ export default class EOASigningStrategy extends EOABaseSigningStrategy {
     constructor(deploy: SavebleDocument<TDeploy>, transaction: Transaction, options: TStrategyOptions | undefined) {
         super(deploy, transaction, options);
         this.privateKey = this.arg(async () => {
-            console.trace("requesting private key");
             return await prompts.privateKey(this.deploy._.chainId);
         }, "overrideEoaPk");
     } 

--- a/src/signing/strategies/eoa/privateKey.ts
+++ b/src/signing/strategies/eoa/privateKey.ts
@@ -14,11 +14,16 @@ export default class EOASigningStrategy extends EOABaseSigningStrategy {
     constructor(deploy: SavebleDocument<TDeploy>, transaction: Transaction, options: TStrategyOptions | undefined) {
         super(deploy, transaction, options);
         this.privateKey = this.arg(async () => {
+            console.trace("requesting private key");
             return await prompts.privateKey(this.deploy._.chainId);
         }, "overrideEoaPk");
     } 
 
     async subclassForgeArgs(): Promise<string[]> {
+        if (this.options?.simulationAddress !== undefined) {
+            return [`--sender`, this.options.simulationAddress];
+        }
+
         return ["--private-key", await this.privateKey.get()]
     }
 
@@ -27,11 +32,20 @@ export default class EOASigningStrategy extends EOABaseSigningStrategy {
     }
 
     async redactInOutput(): Promise<string[]> {
-        const privateKey = await this.privateKey.get();
-        return [privateKey, ...await super.redactInOutput()];
+        const redact = [];
+        try {
+            redact.push(await this.privateKey.getImmediately());
+        } catch {
+            //
+        }
+        return [...redact, ...await super.redactInOutput()];
     }
 
     async getSignerAddress(): Promise<`0x${string}`> {
+        if (this.options?.simulationAddress !== undefined) {
+            return this.options.simulationAddress as `0x${string}`;
+        }
+
         const privateKey = await this.privateKey.get();
         return privateKeyToAccount(privateKey as `0x${string}`).address as `0x${string}`;
     }

--- a/src/signing/strategies/gnosis/api/gnosisEoa.ts
+++ b/src/signing/strategies/gnosis/api/gnosisEoa.ts
@@ -60,6 +60,10 @@ export class GnosisEOAApiStrategy extends GnosisApiStrategy {
     }
 
     async getSignerAddress(): Promise<`0x${string}`> {
+        if (this.options?.simulationAddress !== undefined) {
+            return this.options.simulationAddress as `0x${string}`;
+        }
+
         return privateKeyToAccount(await this.privateKey.get() as `0x${string}`).address as `0x${string}`;
     }
 }

--- a/src/signing/strategy.ts
+++ b/src/signing/strategy.ts
@@ -152,6 +152,7 @@ export class HaltDeployError extends Error {
 export interface TStrategyOptions { 
     defaultArgs: TExecuteOptions,
     nonInteractive: boolean,
+    simulationAddress?: string,
 };
 
 export abstract class Strategy {

--- a/src/tests/deploy/mock.ts
+++ b/src/tests/deploy/mock.ts
@@ -35,14 +35,14 @@ export function mockEnvManifest(): TEnvironmentManifest {
           static: {
             "SampleContract_Impl": {
               deployedBytecodeHash: `0x123`,
-              lastUpdatedIn: {name: '', phase: 'multisig_start', segment: 0},
+              lastUpdatedIn: {name: '', phase: 'multisig_start', segment: 0, signer: `0x0`},
               singleton: true,
               contract: `SampleContract`,
               address: `0xabc`
             },
             "SampleContract_Proxy": {
               deployedBytecodeHash: `0x456`,
-              lastUpdatedIn: {name: '', phase: 'multisig_start', segment: 0},
+              lastUpdatedIn: {name: '', phase: 'multisig_start', segment: 0, signer: `0x0`},
               singleton: true,
               contract: `SampleContract`,
               address: `0xdef`
@@ -51,7 +51,7 @@ export function mockEnvManifest(): TEnvironmentManifest {
           instances: [
             {
               deployedBytecodeHash: `0x456`,
-              lastUpdatedIn: {name: '', phase: 'multisig_start', segment: 0},
+              lastUpdatedIn: {name: '', phase: 'multisig_start', segment: 0, signer: `0x0`},
               singleton: false,
               contract: `SampleContract`,
               address: `0xafd`

--- a/src/tests/deploy/system.spec.ts
+++ b/src/tests/deploy/system.spec.ts
@@ -138,7 +138,8 @@ describe('system steps', () => {
           lastUpdatedIn: {
             phase: 'eoa_start',
             segment: 0,
-            name: 'deployName'
+            name: 'deployName',
+            signer: `0x0`
           }
         }
       ]}


### PR DESCRIPTION
[1.4.3] `zeus deploy verify`

- `zeus deploy verify` no longer requires access to a private key (unless the metadata in question doesn't have record of the msg.sender).
- `zeus deploy verify` now accepts `--deploy` for post-mortem verifying a completed deploy.