### PR TITLE
[1.4.4] update zeus env show --pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 **[Current]** 
+1.4.4:
+    New:
+        - `zeus env show --pending` now highlights which addresses or state parameters have changed.
+
 1.4.3:
     Fixes:
         - `zeus deploy verify` 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/env/cmd/show.ts
+++ b/src/commands/env/cmd/show.ts
@@ -21,12 +21,34 @@ async function handler(_user: TState, args: {json: boolean |undefined, env: stri
         return;
     }
 
+    const preEnv =  await injectableEnvForEnvironment(txn, args.env);
     const env = await injectableEnvForEnvironment(txn, args.env, withDeploy?._.name);
     if (args.json) {
         console.log(JSON.stringify(env))
     } else {
         console.log(chalk.bold.underline(`Environment Parameters`))
-        console.table(env);
+
+        // highlight any parameters that have changed.
+        if (withDeploy) {
+            const keys = Object.keys(env);
+            interface Item {
+                name: string,
+                value: string,
+                dirty: string
+            }
+            const printableEnv: Item[] = [];
+            for (const key of keys) {
+                const item: Item = {
+                    name: key,
+                    value: env[key],
+                    dirty: preEnv[key] !== env[key] ? '⬅️' : ''
+                };
+                printableEnv.push(item);
+            } 
+            console.table(printableEnv);
+        } else {
+            console.table(env);
+        }
     }
 }
 


### PR DESCRIPTION
- `zeus env show [--pending]` now specifically points out values that have changed in the current deploy.