### PR TITLE
[1.5.1] Fix web signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 **[Current]** 
+1.5.1:
+    Fixes:
+        - A distribution bug with 1.5.0 that resulted in the web based signing breaking.
+
 1.5.0:
     Fixes:
         - Issues with ledger ("Unknown Error: 0x650e") will now give you a few attempts to reconnect your device.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layr-labs/zeus",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "BSL",
       "dependencies": {
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layr-labs/zeus",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "web3 deployer / metadata manager",
   "main": "src/index.ts",
   "scripts": {

--- a/src/signing/strategies/gnosis/web/webStrategy.ts
+++ b/src/signing/strategies/gnosis/web/webStrategy.ts
@@ -193,11 +193,7 @@ export class WebGnosisSigningStrategy extends GnosisSigningStrategy {
             // In production this will be included with the package
             let sitePath;
             try {
-                const __filename = fileURLToPath(import.meta.url);
-                const __dirname = dirname(__filename);
-                
-                // Look only in the distribution package path
-                sitePath = path.resolve(__dirname, '../../../../../dist/site-dist');
+                sitePath = path.resolve(__dirname, './site-dist');
                 
                 // If it doesn't exist, log error with debugging information
                 if (!fs.existsSync(sitePath)) {

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -15,6 +15,9 @@ module.exports = {
       },
     ],
   },
+  node: {
+    __dirname: false
+  },
   externals: {
     'usb': 'commonjs usb', 
     'node-hid': 'node-hid',


### PR DESCRIPTION
The computation of the location of `site-dist` relative to the file path was wrong in the bundling case.

Set `__dirname` to false in the webpack config and computed relative to __dirname.