### PR TITLE
feat: enable multisig contract deploy

### DIFF
--- a/src/signing/strategies/gnosis/api/gnosisApi.ts
+++ b/src/signing/strategies/gnosis/api/gnosisApi.ts
@@ -17,7 +17,7 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
     abstract getSignerAddress(): Promise<`0x${string}`>;
 
     async prepare(pathToUpgrade: string): Promise<TSignatureRequest | undefined> {
-        const {output, stateUpdates, safeContext} = await this.runForgeScript(pathToUpgrade);
+        const {output, stateUpdates, safeContext, contractDeploys} = await this.runForgeScript(pathToUpgrade);
         if (!safeContext) {
             throw new Error(`Invalid script -- this was not a multisig script.`);
         }
@@ -33,7 +33,14 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
                 safeAddress: getAddress(safeContext.addr) as `0x${string}`,
                 safeTxHash: undefined,
                 senderAddress: signer as `0x${string}`,
-                stateUpdates
+                stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                })
             }
         }
 
@@ -65,12 +72,19 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
             safeAddress: getAddress(safeContext.addr) as `0x${string}`,
             safeTxHash: hash as `0x${string}`,
             senderAddress: signer as `0x${string}`,
-            stateUpdates
+            stateUpdates,
+            deployedContracts: contractDeploys.map((ct) => {
+                return {
+                    address: ct.addr,
+                    contract: ct.name,
+                    singleton: ct.singleton
+                }
+            })
         }
     }
 
     async requestNew(pathToUpgrade: string): Promise<TSignatureRequest | undefined> {
-        const {output, stateUpdates, safeContext} = await this.runForgeScript(pathToUpgrade);
+        const {output, stateUpdates, safeContext, contractDeploys} = await this.runForgeScript(pathToUpgrade);
         if (!safeContext) {
             throw new Error(`Invalid script -- this was not a multisig script.`);
         }
@@ -86,7 +100,14 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
                 safeAddress: getAddress(safeContext.addr) as `0x${string}`,
                 safeTxHash: undefined,
                 senderAddress: signer as `0x${string}`,
-                stateUpdates
+                stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                })
             }
         }
 
@@ -143,7 +164,14 @@ export abstract class GnosisApiStrategy extends GnosisSigningStrategy {
             safeTxHash: hash as `0x${string}`,
             senderAddress: getAddress(signer) as `0x${string}`,
             signature: senderSignature,
-            stateUpdates
+            stateUpdates,
+            deployedContracts: contractDeploys.map((ct) => {
+                return {
+                    address: ct.addr,
+                    contract: ct.name,
+                    singleton: ct.singleton
+                }
+            })
         }
     }
 

--- a/src/signing/strategies/gnosis/onchain/onchain.ts
+++ b/src/signing/strategies/gnosis/onchain/onchain.ts
@@ -47,7 +47,7 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
 
     async prepare(pathToUpgrade: string): Promise<TSignatureRequest | undefined> {
         const forge = await this.runForgeScript(pathToUpgrade);
-        const {output, stateUpdates, safeContext} = forge;
+        const {output, stateUpdates, safeContext, contractDeploys} = forge;
         if (!safeContext) {
             throw new Error(`Invalid script -- this was not a multisig script.`);
         }
@@ -73,7 +73,14 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
                 safeAddress: getAddress(safeContext.addr) as `0x${string}`,
                 safeTxHash: undefined,
                 senderAddress: signer as `0x${string}`,
-                stateUpdates
+                stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                })
             }
         }
 
@@ -137,6 +144,13 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
             safeTxHash: txHash as `0x${string}`,
             senderAddress: signer as `0x${string}`,
             stateUpdates,
+            deployedContracts: contractDeploys.map((ct) => {
+                return {
+                    address: ct.addr,
+                    contract: ct.name,
+                    singleton: ct.singleton
+                }
+            }),
             immediateExecution: {
                 transaction: undefined,
                 success: simulation.result,
@@ -147,7 +161,7 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
 
     async requestNew(pathToUpgrade: string): Promise<TSignatureRequest | undefined> {
         const forge = await this.runForgeScript(pathToUpgrade);
-        const {output, stateUpdates, safeContext} = forge;
+        const {output, stateUpdates, safeContext, contractDeploys} = forge;
         if (!safeContext) {
             throw new Error(`Invalid script -- this was not a multisig script.`);
         }
@@ -168,7 +182,14 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
                 safeAddress: getAddress(safeContext.addr) as `0x${string}`,
                 safeTxHash: undefined,
                 senderAddress: signer as `0x${string}`,
-                stateUpdates
+                stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                })
             }
         }
 
@@ -241,6 +262,13 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
                 safeTxHash: tx as `0x${string}`,
                 senderAddress: `0x0`,
                 stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                }),
                 immediateExecution: {
                     transaction: tx,
                     success: true,
@@ -282,6 +310,13 @@ export class GnosisOnchainStrategy extends GnosisSigningStrategy {
             safeTxHash: txHash as `0x${string}`,
             senderAddress: signer as `0x${string}`,
             stateUpdates,
+            deployedContracts: contractDeploys.map((ct) => {
+                return {
+                    address: ct.addr,
+                    contract: ct.name,
+                    singleton: ct.singleton
+                }
+            }),
             immediateExecution: {
                 transaction: tx,
                 success: true,

--- a/src/signing/strategies/gnosis/web/webStrategy.ts
+++ b/src/signing/strategies/gnosis/web/webStrategy.ts
@@ -48,7 +48,7 @@ export class WebGnosisSigningStrategy extends GnosisSigningStrategy {
     private resolveSignaturePromise: ((result: TWebModalSignature) => void) | null = null;
 
     async prepare(pathToUpgrade: string): Promise<TSignatureRequest | undefined> {
-        const { output, stateUpdates, safeContext } = await this.runForgeScript(pathToUpgrade);
+        const { output, stateUpdates, safeContext, contractDeploys } = await this.runForgeScript(pathToUpgrade);
         
         if (!safeContext) {
             throw new Error(`Invalid script -- this was not a multisig script.`);
@@ -64,7 +64,14 @@ export class WebGnosisSigningStrategy extends GnosisSigningStrategy {
                 safeAddress: getAddress(safeContext.addr) as `0x${string}`,
                 safeTxHash: undefined,
                 senderAddress: undefined,
-                stateUpdates
+                stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                })
             };
         }
 
@@ -78,12 +85,19 @@ export class WebGnosisSigningStrategy extends GnosisSigningStrategy {
             safeAddress: getAddress(safeContext.addr) as `0x${string}`,
             safeTxHash: undefined,
             senderAddress: undefined,
-            stateUpdates
+            stateUpdates,
+            deployedContracts: contractDeploys.map((ct) => {
+                return {
+                    address: ct.addr,
+                    contract: ct.name,
+                    singleton: ct.singleton
+                }
+            })
         };
     }
 
     async requestNew(pathToUpgrade: string): Promise<TSignatureRequest | undefined> {
-        const { output, stateUpdates, safeContext } = await this.runForgeScript(pathToUpgrade);
+        const { output, stateUpdates, safeContext, contractDeploys } = await this.runForgeScript(pathToUpgrade);
         
         if (!safeContext) {
             throw new Error(`Invalid script -- this was not a multisig script.`);
@@ -99,7 +113,14 @@ export class WebGnosisSigningStrategy extends GnosisSigningStrategy {
                 safeAddress: getAddress(safeContext.addr) as `0x${string}`,
                 safeTxHash: undefined,
                 senderAddress: undefined,
-                stateUpdates
+                stateUpdates,
+                deployedContracts: contractDeploys.map((ct) => {
+                    return {
+                        address: ct.addr,
+                        contract: ct.name,
+                        singleton: ct.singleton
+                    }
+                })
             };
         }
 
@@ -155,7 +176,14 @@ export class WebGnosisSigningStrategy extends GnosisSigningStrategy {
             safeTxHash: hash as `0x${string}`,
             senderAddress: getAddress(sender),
             signature: signature,
-            stateUpdates
+            stateUpdates,
+            deployedContracts: contractDeploys.map((ct) => {
+                return {
+                    address: ct.addr,
+                    contract: ct.name,
+                    singleton: ct.singleton
+                }
+            })
         } as TSignedGnosisRequest;
     }
 

--- a/src/signing/strategy.ts
+++ b/src/signing/strategy.ts
@@ -59,6 +59,8 @@ export interface TGnosisRequest extends HasStateUpdates {
         success: boolean,
         simulation?: unknown
     }
+    // any contracts known to have been deployed by this operation.
+    deployedContracts?: TDeployedContractSparse[] | undefined,
 }
 
 export interface TSignedGnosisRequest extends TGnosisRequest {


### PR DESCRIPTION
**Motivation:**

For the multichain release, we are deploying contracts via Multisigs to enable the same address to be deployed across multiple chains. To do so, we need to update Zeus to be compatible with  

**Modifications:**

Key Updates:
1. Update the `TGnosisRequest` to have `deployedContracts`
2. Update each gnosis strategy (onchain web, api) to parse deployed contracts via `ForgeScript`. This PR: https://github.com/Layr-Labs/zeus-templates/pull/12 emits an event for multisig deploys in our `MultisigBuilder`
3. Update the `gnosis.ts` handler to save deployed contracts to env and their associated bytecode. This mimics what is done in the EOA step

Also add tests. 



**Result:**

Multisig deploy ready 
