### PR TITLE
feat: allow prerelease in semver

### DIFF
--- a/src/commands/deploy/cmd/run.ts
+++ b/src/commands/deploy/cmd/run.ts
@@ -216,7 +216,7 @@ export async function handler(_user: TState, args: {env: string, resume: boolean
         const deployJson = await metaTxn.getJSONFile<TDeploy>(deployJsonPath);
 
         const upgradeManifest = await metaTxn.getJSONFile<TUpgrade>(canonicalPaths.upgradeManifest(args.upgrade));
-        if (!semver.satisfies(envManifest._.deployedVersion ?? '0.0.0', upgradeManifest._.from)) {
+        if (!semver.satisfies(envManifest._.deployedVersion ?? '0.0.0', upgradeManifest._.from, { includePrerelease: true })) {
             console.error(`Unsupported upgrade. ${upgradeManifest._.name} requires an environment meet the following version criteria: (${upgradeManifest._.from})`);
             console.error(`Environment ${envManifest._.id} is currently deployed at '${envManifest._.deployedVersion}'`);
             return;

--- a/src/commands/upgrade/cmd/list.ts
+++ b/src/commands/upgrade/cmd/list.ts
@@ -36,7 +36,7 @@ export const handler = async function(_user: TState, args: {env: string | undefi
 
 
     if (forRequiredVersion !== undefined) {
-        upgradesAndManifests = upgradesAndManifests.filter(upMan => semver.satisfies(forRequiredVersion, upMan.manifest._.from));
+        upgradesAndManifests = upgradesAndManifests.filter(upMan => semver.satisfies(forRequiredVersion, upMan.manifest._.from, { includePrerelease: true }));
     }
 
     upgradesAndManifests.forEach(data => {

--- a/src/commands/upgrade/utils.ts
+++ b/src/commands/upgrade/utils.ts
@@ -15,7 +15,7 @@ export function findUpgradePaths(from: string, to: string, allUpgrades: TUpgrade
     const allPaths: Path[] = [];
     const availableRoutes: TPartialRoute[] = 
         allUpgrades
-            .filter(upgrade => semver.satisfies(from, upgrade.from))
+            .filter(upgrade => semver.satisfies(from, upgrade.from, { includePrerelease: true }))
             .map((upgrade) => {
                 return {
                     version: upgrade.to,
@@ -34,7 +34,7 @@ export function findUpgradePaths(from: string, to: string, allUpgrades: TUpgrade
 
         // see what upgrades we have available.
         allUpgrades
-            .filter(upgrade => semver.satisfies(route.version, upgrade.from) && !route.upgradePath.includes(upgrade.name))
+            .filter(upgrade => semver.satisfies(route.version, upgrade.from, { includePrerelease: true }) && !route.upgradePath.includes(upgrade.name))
             .map<TPartialRoute>(upgrade => {
                 return {
                     version: upgrade.to,

--- a/src/tests/commands/semver-prerelease.spec.ts
+++ b/src/tests/commands/semver-prerelease.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from '@jest/globals';
+import semver from 'semver';
+
+describe('semver prerelease handling with includePrerelease option', () => {
+  describe('semver.satisfies with includePrerelease: true', () => {
+    it('should match prerelease versions with >= ranges', () => {
+      // The exact case from the user's issue
+      expect(semver.satisfies('1.7.0-rc.0', '>=1.3.0', { includePrerelease: true })).toBe(true);
+      
+      // Additional test cases
+      expect(semver.satisfies('2.0.0-alpha.1', '>=1.0.0', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('1.0.0-beta.1', '>=0.9.0', { includePrerelease: true })).toBe(true);
+    });
+
+    it('should not match prerelease versions with >= ranges without includePrerelease', () => {
+      // Without the option, prereleases are excluded
+      expect(semver.satisfies('1.7.0-rc.0', '>=1.3.0')).toBe(false);
+      expect(semver.satisfies('2.0.0-alpha.1', '>=1.0.0')).toBe(false);
+      expect(semver.satisfies('1.0.0-beta.1', '>=0.9.0')).toBe(false);
+    });
+
+    it('should work with caret ranges and prereleases', () => {
+      expect(semver.satisfies('1.2.3-alpha.1', '^1.2.0', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('2.0.0-rc.1', '^2.0.0-0', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('1.5.0-beta.2', '^1.0.0', { includePrerelease: true })).toBe(true);
+      
+      // Without includePrerelease
+      expect(semver.satisfies('1.2.3-alpha.1', '^1.2.0')).toBe(false);
+    });
+
+    it('should work with tilde ranges and prereleases', () => {
+      expect(semver.satisfies('1.2.3-alpha.1', '~1.2.0', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('1.2.0-rc.1', '~1.2.0-0', { includePrerelease: true })).toBe(true);
+      
+      // Without includePrerelease
+      expect(semver.satisfies('1.2.3-alpha.1', '~1.2.0')).toBe(false);
+    });
+
+    it('should respect version boundaries even with includePrerelease', () => {
+      // Prerelease should still respect version boundaries
+      expect(semver.satisfies('1.0.0-alpha.1', '>=2.0.0', { includePrerelease: true })).toBe(false);
+      expect(semver.satisfies('0.9.0-rc.1', '^1.0.0', { includePrerelease: true })).toBe(false);
+    });
+
+    it('should handle complex prerelease identifiers', () => {
+      expect(semver.satisfies('1.0.0-alpha.beta', '>=1.0.0-alpha', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('1.0.0-rc.1.2.3', '>=1.0.0-beta', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('2.0.0-20230101.1', '>=1.5.0', { includePrerelease: true })).toBe(true);
+    });
+
+    it('should match exact prerelease versions', () => {
+      expect(semver.satisfies('1.0.0-alpha.1', '1.0.0-alpha.1', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('1.0.0-alpha.1', '1.0.0-alpha.2', { includePrerelease: true })).toBe(false);
+    });
+
+    it('should handle wildcards with prereleases', () => {
+      expect(semver.satisfies('1.2.3-alpha', '*', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('0.0.1-beta', '*', { includePrerelease: true })).toBe(true);
+      
+      // Without includePrerelease, * doesn't match prereleases
+      expect(semver.satisfies('1.2.3-alpha', '*')).toBe(false);
+    });
+  });
+
+  describe('edge cases and special scenarios', () => {
+    it('should handle -0 suffix for including prereleases in ranges', () => {
+      // Using -0 suffix is another way to include prereleases
+      expect(semver.satisfies('1.0.0-rc.1', '>=1.0.0-0')).toBe(true);
+      expect(semver.satisfies('2.0.0-alpha', '>=2.0.0-0')).toBe(true);
+    });
+
+    it('should differentiate between includePrerelease option and -0 suffix', () => {
+      // With -0 suffix, prereleases of that version are included
+      expect(semver.satisfies('1.0.0-rc.1', '>=1.0.0-0')).toBe(true);
+      // Prereleases of higher versions are not included without includePrerelease
+      expect(semver.satisfies('2.0.0-rc.1', '>=1.0.0-0')).toBe(false);
+      
+      // With includePrerelease, all prereleases in range are included
+      expect(semver.satisfies('1.5.0-beta', '>=1.0.0', { includePrerelease: true })).toBe(true);
+      expect(semver.satisfies('2.0.0-rc.1', '>=1.0.0', { includePrerelease: true })).toBe(true);
+    });
+  });
+}); 

--- a/src/tests/commands/upgrade/utils.spec.ts
+++ b/src/tests/commands/upgrade/utils.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from '@jest/globals';
+import { findUpgradePaths } from '../../../commands/upgrade/utils';
+import { TUpgrade } from '../../../metadata/schema';
+
+describe('upgrade utils', () => {
+  describe('findUpgradePaths with prerelease versions', () => {
+    const createUpgrade = (name: string, from: string, to: string): TUpgrade => ({
+      name,
+      from,
+      to,
+      phases: [],
+      commit: '0x123'
+    });
+
+    it('should find upgrade paths from release candidate to stable version', () => {
+      const upgrades: TUpgrade[] = [
+        createUpgrade('rc-to-stable', '1.7.0-rc.0', '1.7.0'),
+        createUpgrade('stable-to-next', '1.7.0', '1.7.1'),
+      ];
+
+      const paths = findUpgradePaths('1.7.0-rc.0', '1.7.1', upgrades);
+      expect(paths).toBeDefined();
+      expect(paths?.length).toBe(1);
+      expect(paths?.[0]).toEqual(['rc-to-stable', 'stable-to-next']);
+    });
+
+    it('should match prerelease versions with >=X.Y.Z ranges', () => {
+      const upgrades: TUpgrade[] = [
+        createUpgrade('redistribution', '>=1.3.0', '1.7.1'),
+      ];
+
+      // This should work now with includePrerelease: true
+      const paths = findUpgradePaths('1.7.0-rc.0', '1.7.1', upgrades);
+      expect(paths).toBeDefined();
+      expect(paths?.length).toBe(1);
+      expect(paths?.[0]).toEqual(['redistribution']);
+    });
+
+    it('should handle complex prerelease version chains', () => {
+      const upgrades: TUpgrade[] = [
+        createUpgrade('alpha-to-beta', '1.5.0-alpha.1', '1.5.0-beta.1'),
+        createUpgrade('beta-to-rc', '1.5.0-beta.1', '1.5.0-rc.1'),
+        createUpgrade('rc-to-stable', '1.5.0-rc.1', '1.5.0'),
+        createUpgrade('patch-update', '1.5.0', '1.5.1'),
+      ];
+
+      const paths = findUpgradePaths('1.5.0-alpha.1', '1.5.1', upgrades);
+      expect(paths).toBeDefined();
+      expect(paths?.length).toBe(1);
+      expect(paths?.[0]).toEqual(['alpha-to-beta', 'beta-to-rc', 'rc-to-stable', 'patch-update']);
+    });
+
+    it('should match prerelease versions with caret ranges', () => {
+      const upgrades: TUpgrade[] = [
+        createUpgrade('major-upgrade', '^1.0.0', '2.0.0'),
+      ];
+
+      const paths = findUpgradePaths('1.5.0-rc.2', '2.0.0', upgrades);
+      expect(paths).toBeDefined();
+      expect(paths?.length).toBe(1);
+      expect(paths?.[0]).toEqual(['major-upgrade']);
+    });
+
+    it('should match prerelease versions with tilde ranges', () => {
+      const upgrades: TUpgrade[] = [
+        createUpgrade('patch-upgrade', '~1.5.0-0', '1.5.10'),
+      ];
+
+      const paths = findUpgradePaths('1.5.0-rc.1', '1.5.10', upgrades);
+      expect(paths).toBeDefined();
+      expect(paths?.length).toBe(1);
+      expect(paths?.[0]).toEqual(['patch-upgrade']);
+    });
+
+    it('should handle multiple paths with prereleases', () => {
+      const upgrades: TUpgrade[] = [
+        // Path 1: Direct upgrade
+        createUpgrade('direct', '>=1.0.0-0', '2.0.0'),
+        // Path 2: Step by step
+        createUpgrade('to-stable', '1.0.0-rc.1', '1.0.0'),
+        createUpgrade('major-bump', '1.0.0', '2.0.0'),
+      ];
+
+      const paths = findUpgradePaths('1.0.0-rc.1', '2.0.0', upgrades);
+      expect(paths).toBeDefined();
+      // With includePrerelease, it might find additional paths
+      expect(paths?.length).toBeGreaterThanOrEqual(2);
+      // Should find both expected paths
+      const pathNames = paths?.map(p => p.join(','));
+      expect(pathNames).toContain('direct');
+      expect(pathNames).toContain('to-stable,major-bump');
+    });
+
+    it('should not find paths when prerelease does not match', () => {
+      const upgrades: TUpgrade[] = [
+        createUpgrade('specific-prerelease', '1.0.0-alpha.1', '1.0.0'),
+      ];
+
+      // Different prerelease should not match
+      const paths = findUpgradePaths('1.0.0-beta.1', '1.0.0', upgrades);
+      expect(paths).toBeDefined();
+      expect(paths?.length).toBe(0);
+    });
+  });
+}); 


### PR DESCRIPTION
Per EigenGit, we now have semantic versioning using pre release (eg. `v.1.7.0-rc.0`). This PR recognizes pre releases as a valid semver by setting `includePrerelease: true`. 